### PR TITLE
Fixes isobject and flatten no loading. 

### DIFF
--- a/angular-cli-build.js
+++ b/angular-cli-build.js
@@ -24,6 +24,7 @@ module.exports = function(defaults) {
       'whatwg-fetch/**/*.+(js|js.map)',
       'lodash/**/*.+(js|js.map)',
       'lodash.**/**/*.+(js|js.map)',
+      'lodash.flatten/*.+(js|js.map)',
       'redux/dist/redux.min.js',
       'symbol-observable/**/*.+(js|js.map)'
     ]

--- a/angular-cli-build.js
+++ b/angular-cli-build.js
@@ -24,7 +24,6 @@ module.exports = function(defaults) {
       'whatwg-fetch/**/*.+(js|js.map)',
       'lodash/**/*.+(js|js.map)',
       'lodash.**/**/*.+(js|js.map)',
-      'lodash.flatten/*.+(js|js.map)',
       'redux/dist/redux.min.js',
       'symbol-observable/**/*.+(js|js.map)'
     ]

--- a/src/system-config.ts
+++ b/src/system-config.ts
@@ -15,7 +15,9 @@ const map: any = {
   'whatwg-fetch': 'vendor/whatwg-fetch',
   'redux': 'vendor/redux/dist/redux.min.js',
   'symbol-observable': 'vendor/symbol-observable',
-  'lodash': 'vendor/lodash'
+  'lodash': 'vendor/lodash',
+  'lodash.flatten': 'vendor/lodash.flatten',
+  'lodash.isobject': 'vendor/lodash.isobject'
 };
 
 /** User packages configuration. */
@@ -53,6 +55,14 @@ const packages: any = {
     main: 'index.js'
   },
   'lodash': {
+    defaultExtension: 'js',
+    main: 'index.js'
+  },
+  'lodash.flatten': {
+    defaultExtension: 'js',
+    main: 'index.js'
+  },
+  'lodash.isobject': {
     defaultExtension: 'js',
     main: 'index.js'
   }


### PR DESCRIPTION
Right now isobject and flatten from lodash need to be manually added to the system map in config. This does that. 
